### PR TITLE
makes colorize a dependency of the gem, not just development

### DIFF
--- a/lib/podspec_bump.rb
+++ b/lib/podspec_bump.rb
@@ -40,7 +40,7 @@ module PodspecBump
     def self.commit(version, options)
       return unless File.directory?(".git")
       system_cmd("git add --update #{spec_file()} && git commit -m 'v#{version}'")
-      system_cmd("git tag -a -m 'Bump to v#{version}' #{version}")
+      system_cmd("git tag -a -m 'Bump to v#{version}' v#{version}")
     end
 
     def self.system_cmd(command)

--- a/lib/podspec_bump.rb
+++ b/lib/podspec_bump.rb
@@ -1,5 +1,4 @@
 require "podspec_bump/version"
-require 'colorize'
 
 module PodspecBump
   class InvalidOptionError < StandardError; end
@@ -15,16 +14,16 @@ module PodspecBump
       when *BUMPS
         bump_part(bump, options)
       when "current"
-        puts "Current version: #{version_from_file()}".colorize(:green)
+        puts "Current version: #{version_from_file()}"
       else
         raise InvalidOptionError
       end
     rescue InvalidOptionError
-      puts "Invalid option. Choose between #{OPTIONS.join(',')}.".colorize(:yellow)
+      puts "Invalid option. Choose between #{OPTIONS.join(',')}."
     rescue NotfoundSpecFileError
-      puts "Not found your spec file".colorize(:yellow)
+      puts "Not found your spec file"
     rescue Exception => e
-      puts "Something wrong happened: #{e.message}\n#{e.backtrace.join("\n")}".colorize(:yellow)
+      puts "Something wrong happened: #{e.message}\n#{e.backtrace.join("\n")}"
     end
 
     def self.bump(current, next_version, options)
@@ -45,7 +44,7 @@ module PodspecBump
     end
 
     def self.system_cmd(command)
-      puts command.colorize(:green)
+      puts command
       system command
     end
 

--- a/podspec_bump.gemspec
+++ b/podspec_bump.gemspec
@@ -21,6 +21,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-
-  spec.add_dependency "colorize"
 end

--- a/podspec_bump.gemspec
+++ b/podspec_bump.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "colorize"
+
+  spec.add_dependency "colorize"
 end


### PR DESCRIPTION
When installing `podspec_bump` in a vendored gem environment or a CI environment, unless the `colorize` gem is already installed, `podspec_bump` will not work.